### PR TITLE
Mofified code to introduce capability to write data to whatever users name

### DIFF
--- a/demos/franka_pick_place_demo_script.py
+++ b/demos/franka_pick_place_demo_script.py
@@ -123,7 +123,9 @@ def main():
 
     # 2. Extract its directory
     #script_dir = os.path.dirname(script_path)
-    script_dir = '/home/student/data/franka_baselines/demos/pick_n_place' # Assumes data folder in user directory.
+    #script_dir = '/home/student/data/franka_baselines/demos/pick_n_place' # Assumes data folder in user directory.
+    script_dir = os.path.expanduser('~/data/franka_baselines/demos/pick_n_place')
+    os.makedirs(script_dir, exist_ok=True)
 
     # 3. Create output filename with configuration details
     fileName = "data_" + robot


### PR DESCRIPTION
Code was failing to write demo information when user name was different than student. 

Now use expanduser to replace '~' with whatever the current user’s home (/home/bison, /home/student, etc.) is.